### PR TITLE
requests version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ _REQUIRES = [
     'nose',
     'numpy>=1.7',
     'netCDF4>=1.2.1',
-    'requests',
+    'requests==2.20.0',
     'psutil>=0.6.0'
     ]
 


### PR DESCRIPTION
Hi, just a nudge here to get this working for ESGF, as not having a consistent requests version across modules is breaking our installs.  We will hopefully move to flexible versions (ie >=) but ESGF is weighing a decision regarding reproducible installs.  Could we get the next cdf2cim version once available in pypi?