### PR TITLE
Remove requests version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ _REQUIRES = [
     'nose',
     'numpy>=1.7',
     'netCDF4>=1.2.1',
-    'requests==2.20.0',
+    'requests>=2.22.0',
     'psutil>=0.6.0'
     ]
 


### PR DESCRIPTION
It was a bad idea a while ago to request that all packages be pinned to a version, now outdated.  Lets remove this going forward